### PR TITLE
fix(pkgbuild): correct t3code launcher exec path

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = t3code-bin
 	pkgdesc = T3 Code desktop app packaged from the upstream AppImage
 	pkgver = 0.0.17
-	pkgrel = 1
+	pkgrel = 2
 	url = https://t3.codes
 	arch = x86_64
 	license = MIT

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=t3code-bin
 pkgver=0.0.17
-pkgrel=1
+pkgrel=2
 pkgdesc='T3 Code desktop app packaged from the upstream AppImage'
 arch=('x86_64')
 _upstream_tag='v0.0.17'
@@ -96,7 +96,7 @@ else
   extra_flags+=(--ozone-platform-hint=auto)
 fi
 
-exec "$appdir/usr/bin/t3code" --no-sandbox "${extra_flags[@]}" "$@"
+exec "$appdir/t3code" --no-sandbox "${extra_flags[@]}" "$@"
 EOF
 
   ln -s t3code "$pkgdir/usr/bin/t3-code-desktop"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -102,22 +102,22 @@ EOF
   ln -s t3code "$pkgdir/usr/bin/t3-code-desktop"
 
   install -Dm644 "$srcdir/t3code-icon.png" \
-    "$pkgdir/usr/share/icons/hicolor/1024x1024/apps/t3-code-desktop.png"
-  ln -s t3-code-desktop.png \
     "$pkgdir/usr/share/icons/hicolor/1024x1024/apps/t3code.png"
+  ln -s t3code.png \
+    "$pkgdir/usr/share/icons/hicolor/1024x1024/apps/t3-code-desktop.png"
   install -Dm644 "$srcdir/t3code-icon.png" \
-    "$pkgdir/usr/share/pixmaps/t3-code-desktop.png"
-  ln -s t3-code-desktop.png "$pkgdir/usr/share/pixmaps/t3code.png"
+    "$pkgdir/usr/share/pixmaps/t3code.png"
+  ln -s t3code.png "$pkgdir/usr/share/pixmaps/t3-code-desktop.png"
 
-  install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/t3-code-desktop.desktop" << 'EOF'
+  install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/t3code.desktop" << 'EOF'
 [Desktop Entry]
 Name=T3 Code
 Comment=T3 Code desktop build
 Exec=t3code %U
 Terminal=false
 Type=Application
-Icon=t3-code-desktop
-StartupWMClass=T3 Code (Alpha)
+Icon=t3code
+StartupWMClass=t3code
 Categories=Development;
 EOF
 


### PR DESCRIPTION
This corrects the launcher exec path from `$appdir/usr/bin/t3code` to `$appdir/t3code`, matching the actual AppImage layout where the renamed binary lives at the payload root. Without this, 0.0.16-2 and 0.0.17-1 crash on launch with `/usr/bin/t3code: line 22: /opt/t3code-bin/usr/bin/t3code: No such file or directory`.