### PR TITLE
fix(pkgbuild): correct launcher binary path

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -96,7 +96,7 @@ else
   extra_flags+=(--ozone-platform-hint=auto)
 fi
 
-exec "$appdir/usr/bin/t3code" --no-sandbox "${extra_flags[@]}" "$@"
+exec "$appdir/t3code" --no-sandbox "${extra_flags[@]}" "$@"
 EOF
 
   ln -s t3code "$pkgdir/usr/bin/t3-code-desktop"


### PR DESCRIPTION
Launch script (`$pkgdir/usr/bin/t3code`)  tries to run `/opt/t3code-bin/usr/bin/t3code`  ($appdir/usr/bin/t3code)

package installs the real binary at /opt/t3code-bin/t3code