### PR TITLE
fix nightly launcher icon

### DIFF
--- a/packages/t3code-nightly-bin/.SRCINFO
+++ b/packages/t3code-nightly-bin/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = t3code-nightly-bin
 	pkgdesc = T3 Code nightly desktop app packaged from the upstream AppImage
 	pkgver = 0.0.21_nightly.20260417.58
-	pkgrel = 1
+	pkgrel = 2
 	url = https://t3.codes
 	arch = x86_64
 	license = MIT

--- a/packages/t3code-nightly-bin/PKGBUILD
+++ b/packages/t3code-nightly-bin/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=t3code-nightly-bin
 pkgver=0.0.21_nightly.20260417.58
-pkgrel=1
+pkgrel=2
 pkgdesc='T3 Code nightly desktop app packaged from the upstream AppImage'
 arch=('x86_64')
 _upstream_tag='nightly-v0.0.21-nightly.20260417.58'
@@ -117,6 +117,7 @@ Exec=t3code-nightly %U
 Terminal=false
 Type=Application
 Icon=t3code-nightly
+StartupWMClass=t3code
 Categories=Development;
 EOF
 


### PR DESCRIPTION
## Summary

Fixes the `t3code-nightly-bin` launcher icon mismatch on Linux by adding `StartupWMClass=t3code` to the generated nightly desktop entry.

The nightly package already installs an icon, but COSMIC and other desktop environments need the window class to match the running Electron window back to the `.desktop` metadata. The stable package already includes this field.

## Changes

- Add `StartupWMClass=t3code` to `packages/t3code-nightly-bin/PKGBUILD`
- Bump `pkgrel` from `1` to `2` for the packaging-only fix
- Regenerate `packages/t3code-nightly-bin/.SRCINFO`

## Verification

- Confirmed the generated desktop entry now includes `StartupWMClass=t3code`
- Confirmed `.SRCINFO` reflects `pkgrel = 2`

Fixes #8